### PR TITLE
fix: invalidate query cache when plugin loads after nvim-treesitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Lazy loading with `ft` no longer breaks injection queries** — when the plugin loads after
+  nvim-treesitter has already cached markdown queries (e.g. lazy.nvim `ft`-based loading), the
+  plugin now invalidates the query cache and restarts tree-sitter highlighting on already-open
+  buffers so that MyST injection patterns like `{code-cell}` are picked up.
+
+### Changed
+- **Recommended lazy.nvim config uses `event = "VeryLazy"` instead of `ft`** — this avoids
+  query cache timing issues entirely by ensuring the plugin is in the runtimepath before any
+  files are opened.
+
 ## [0.5.1] - 2026-02-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Lazy loading with `ft` no longer breaks injection queries** — when the plugin loads after
   nvim-treesitter has already cached markdown queries (e.g. lazy.nvim `ft`-based loading), the
-  plugin now invalidates the query cache and restarts tree-sitter highlighting on already-open
-  buffers so that MyST injection patterns like `{code-cell}` are picked up.
-
-### Changed
-- **Recommended lazy.nvim config uses `event = "VeryLazy"` instead of `ft`** — this avoids
-  query cache timing issues entirely by ensuring the plugin is in the runtimepath before any
-  files are opened.
+  plugin now invalidates the query cache, re-detects MyST filetypes, and restarts tree-sitter
+  highlighting on already-open buffers so that MyST injection patterns like `{code-cell}` are
+  picked up automatically.
 
 ## [0.5.1] - 2026-02-17
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
 {
   'QuantEcon/myst-markdown-tree-sitter.nvim',
   dependencies = {'nvim-treesitter/nvim-treesitter'},
-  ft = {"markdown", "myst"},
+  event = "VeryLazy",
   config = function()
     require('myst-markdown').setup()
   end,
-  priority = 1000, -- Load after other markdown plugins
 }
 ```
 
@@ -39,7 +38,7 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
   "QuantEcon/myst-markdown-tree-sitter.nvim",
   version = "0.5.1",  -- Pin to specific version for stability
   dependencies = { "nvim-treesitter/nvim-treesitter" },
-  ft = { "markdown", "myst" },
+  event = "VeryLazy",
   config = function()
     require('myst-markdown').setup({
       debug = false,  -- Set true for troubleshooting
@@ -54,15 +53,15 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
       },
     })
   end,
-  priority = 1000,
 }
 ```
 
 **Configuration Options Explained:**
 - `version = "0.5.1"` - Pin to a specific release for stability, or use `version = "*"` for latest
-- `ft = {"markdown", "myst"}` - Lazy loads the plugin only when opening markdown or MyST files, improving startup performance
-- `priority = 1000` - Ensures this plugin loads after other markdown plugins to prevent highlighting conflicts
+- `event = "VeryLazy"` - Loads the plugin after startup but before any files are opened, ensuring tree-sitter injection queries are available when markdown files open
 - `config` function - Runs the setup after treesitter is properly loaded
+
+> **Note:** Avoid using `ft = {"markdown", "myst"}` for lazy loading. This can cause the plugin to load *after* nvim-treesitter has already cached markdown queries, which means MyST injection patterns (like `{code-cell}` highlighting) may not take effect. The plugin includes a workaround for this, but `event = "VeryLazy"` avoids the issue entirely.
 
 ### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
@@ -87,13 +86,12 @@ To test unreleased changes from a specific branch (useful for testing fixes befo
   'QuantEcon/myst-markdown-tree-sitter.nvim',
   branch = 'branch-name',  -- Replace with the actual branch name
   dependencies = {'nvim-treesitter/nvim-treesitter'},
-  ft = {"markdown", "myst"},
+  event = "VeryLazy",
   config = function()
     -- Your MyST setup here
     -- Ensure this runs after treesitter is loaded
     require('myst-markdown').setup()
   end,
-  priority = 1000, -- Load after other markdown plugins
 }
 ```
 
@@ -238,6 +236,7 @@ If MyST highlighting is not working:
 - Check if the language parser is installed: `:TSInstall <language>`
 - Example: For Python highlighting, run `:TSInstall python`
 - Verify parser is loaded: `:lua print(vim.inspect(require('nvim-treesitter.parsers').get_parser()))`
+- If using lazy.nvim with `ft = {"markdown", "myst"}`, switch to `event = "VeryLazy"` — `ft`-based loading can cause the plugin's injection queries to be missed (see note in Installation section above)
 
 **Math directive highlighting not working?**
 - Install the LaTeX parser: `:TSInstall latex`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
 {
   'QuantEcon/myst-markdown-tree-sitter.nvim',
   dependencies = {'nvim-treesitter/nvim-treesitter'},
-  event = "VeryLazy",
+  ft = {"markdown", "myst"},
   config = function()
     require('myst-markdown').setup()
   end,
@@ -38,7 +38,7 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
   "QuantEcon/myst-markdown-tree-sitter.nvim",
   version = "0.5.1",  -- Pin to specific version for stability
   dependencies = { "nvim-treesitter/nvim-treesitter" },
-  event = "VeryLazy",
+  ft = { "markdown", "myst" },
   config = function()
     require('myst-markdown').setup({
       debug = false,  -- Set true for troubleshooting
@@ -58,10 +58,10 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
 
 **Configuration Options Explained:**
 - `version = "0.5.1"` - Pin to a specific release for stability, or use `version = "*"` for latest
-- `event = "VeryLazy"` - Loads the plugin after startup but before any files are opened, ensuring tree-sitter injection queries are available when markdown files open
+- `ft = {"markdown", "myst"}` - Lazy loads the plugin only when opening markdown or MyST files
 - `config` function - Runs the setup after treesitter is properly loaded
 
-> **Note:** Avoid using `ft = {"markdown", "myst"}` for lazy loading. This can cause the plugin to load *after* nvim-treesitter has already cached markdown queries, which means MyST injection patterns (like `{code-cell}` highlighting) may not take effect. The plugin includes a workaround for this, but `event = "VeryLazy"` avoids the issue entirely.
+> **Note:** The plugin automatically handles tree-sitter query cache invalidation when it loads after nvim-treesitter has already cached markdown queries, so `ft`-based loading works correctly.
 
 ### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
@@ -86,7 +86,7 @@ To test unreleased changes from a specific branch (useful for testing fixes befo
   'QuantEcon/myst-markdown-tree-sitter.nvim',
   branch = 'branch-name',  -- Replace with the actual branch name
   dependencies = {'nvim-treesitter/nvim-treesitter'},
-  event = "VeryLazy",
+  ft = {"markdown", "myst"},
   config = function()
     -- Your MyST setup here
     -- Ensure this runs after treesitter is loaded
@@ -236,7 +236,9 @@ If MyST highlighting is not working:
 - Check if the language parser is installed: `:TSInstall <language>`
 - Example: For Python highlighting, run `:TSInstall python`
 - Verify parser is loaded: `:lua print(vim.inspect(require('nvim-treesitter.parsers').get_parser()))`
-- If using lazy.nvim with `ft = {"markdown", "myst"}`, switch to `event = "VeryLazy"` — `ft`-based loading can cause the plugin's injection queries to be missed (see note in Installation section above)
+
+**Conflicts with other MyST plugins?**
+- If you previously used a standalone `myst-markdown` plugin (not this one), remove it — it can conflict with `myst-markdown-tree-sitter.nvim`'s filetype detection and query injection
 
 **Math directive highlighting not working?**
 - Install the LaTeX parser: `:TSInstall latex`

--- a/doc/myst-markdown.txt
+++ b/doc/myst-markdown.txt
@@ -56,18 +56,16 @@ Using lazy.nvim ~
     {
       'QuantEcon/myst-markdown-tree-sitter.nvim',
       dependencies = {'nvim-treesitter/nvim-treesitter'},
-      event = "VeryLazy",
+      ft = {"markdown", "myst"},
       config = function()
         require('myst-markdown').setup()
       end,
     }
 <
 
-Note: Avoid using `ft = {"markdown", "myst"}` for lazy loading. This can
-cause the plugin to load after nvim-treesitter has already cached markdown
-queries, which means MyST injection patterns (like `{code-cell}` highlighting)
-may not take effect. The plugin includes a workaround that invalidates the
-query cache on setup, but `event = "VeryLazy"` avoids the issue entirely.
+Note: The plugin automatically handles tree-sitter query cache
+invalidation when it loads after nvim-treesitter has already cached
+markdown queries, so `ft`-based loading works correctly.
 
 Using packer.nvim ~
 >lua
@@ -278,18 +276,19 @@ Conflicts with other markdown plugins ~
 
 If experiencing conflicts:
 
-1. Use `event = "VeryLazy"` in lazy.nvim config instead of `ft`-based loading
-2. Ensure myst-markdown is loaded after other markdown-related plugins
+1. Remove any standalone `myst-markdown` plugin — it conflicts with this one
+2. Ensure myst-markdown-tree-sitter.nvim is loaded after other markdown plugins
 3. Check for duplicate filetype detections in other plugins
 
 Lazy loading issues ~
 
 If code-cell highlighting doesn't work with lazy.nvim:
 
-1. Switch from `ft = {"markdown", "myst"}` to `event = "VeryLazy"`
-2. If you must use `ft`, the plugin will attempt to invalidate the query
-   cache automatically, but results may vary across Neovim versions
+1. Ensure you are using `ft = {"markdown", "myst"}` in your plugin spec
+2. The plugin automatically invalidates the query cache when it loads
+   after nvim-treesitter, so injection queries should work
 3. Run |:MystDebug| to verify injection queries are loaded
+4. If you previously used a standalone `myst-markdown` plugin, remove it
 
 Getting help ~
 

--- a/doc/myst-markdown.txt
+++ b/doc/myst-markdown.txt
@@ -56,13 +56,18 @@ Using lazy.nvim ~
     {
       'QuantEcon/myst-markdown-tree-sitter.nvim',
       dependencies = {'nvim-treesitter/nvim-treesitter'},
-      ft = {"markdown", "myst"},
+      event = "VeryLazy",
       config = function()
         require('myst-markdown').setup()
       end,
-      priority = 1000,
     }
 <
+
+Note: Avoid using `ft = {"markdown", "myst"}` for lazy loading. This can
+cause the plugin to load after nvim-treesitter has already cached markdown
+queries, which means MyST injection patterns (like `{code-cell}` highlighting)
+may not take effect. The plugin includes a workaround that invalidates the
+query cache on setup, but `event = "VeryLazy"` avoids the issue entirely.
 
 Using packer.nvim ~
 >lua
@@ -273,9 +278,18 @@ Conflicts with other markdown plugins ~
 
 If experiencing conflicts:
 
-1. Set `priority = 1000` in lazy.nvim config to load after other plugins
+1. Use `event = "VeryLazy"` in lazy.nvim config instead of `ft`-based loading
 2. Ensure myst-markdown is loaded after other markdown-related plugins
 3. Check for duplicate filetype detections in other plugins
+
+Lazy loading issues ~
+
+If code-cell highlighting doesn't work with lazy.nvim:
+
+1. Switch from `ft = {"markdown", "myst"}` to `event = "VeryLazy"`
+2. If you must use `ft`, the plugin will attempt to invalidate the query
+   cache automatically, but results may vary across Neovim versions
+3. Run |:MystDebug| to verify injection queries are loaded
 
 Getting help ~
 

--- a/examples/lazy-nvim.lua
+++ b/examples/lazy-nvim.lua
@@ -10,7 +10,7 @@ return {
   },
   
   -- Load after startup so injection queries are in runtimepath before any
-  -- markdown file opens.  Avoid ft = {"markdown","myst"} because that can
+  -- markdown file opens.  Avoid ft = {"markdown", "myst"} because that can
   -- cause the plugin to load after nvim-treesitter has already cached
   -- markdown queries, which may prevent {code-cell} highlighting.
   event = "VeryLazy",

--- a/examples/lazy-nvim.lua
+++ b/examples/lazy-nvim.lua
@@ -9,11 +9,11 @@ return {
     'nvim-treesitter/nvim-treesitter',
   },
   
-  -- Lazy load only for markdown and myst files
-  ft = { "markdown", "myst" },
-  
-  -- Load after other markdown plugins to prevent conflicts
-  priority = 1000,
+  -- Load after startup so injection queries are in runtimepath before any
+  -- markdown file opens.  Avoid ft = {"markdown","myst"} because that can
+  -- cause the plugin to load after nvim-treesitter has already cached
+  -- markdown queries, which may prevent {code-cell} highlighting.
+  event = "VeryLazy",
   
   -- Plugin configuration
   config = function()
@@ -55,8 +55,7 @@ return {
 --   {
 --     'QuantEcon/myst-markdown-tree-sitter.nvim',
 --     dependencies = { 'nvim-treesitter/nvim-treesitter' },
---     ft = { "markdown", "myst" },
---     priority = 1000,
+--     event = "VeryLazy",
 --     config = function()
 --       require('myst-markdown').setup()
 --     end,

--- a/examples/lazy-nvim.lua
+++ b/examples/lazy-nvim.lua
@@ -9,11 +9,10 @@ return {
     'nvim-treesitter/nvim-treesitter',
   },
   
-  -- Load after startup so injection queries are in runtimepath before any
-  -- markdown file opens.  Avoid ft = {"markdown", "myst"} because that can
-  -- cause the plugin to load after nvim-treesitter has already cached
-  -- markdown queries, which may prevent {code-cell} highlighting.
-  event = "VeryLazy",
+  -- Lazy load only for markdown and myst files.
+  -- The plugin automatically invalidates the tree-sitter query cache when
+  -- it loads after nvim-treesitter, so ft-based loading works correctly.
+  ft = { "markdown", "myst" },
   
   -- Plugin configuration
   config = function()
@@ -55,7 +54,7 @@ return {
 --   {
 --     'QuantEcon/myst-markdown-tree-sitter.nvim',
 --     dependencies = { 'nvim-treesitter/nvim-treesitter' },
---     event = "VeryLazy",
+--     ft = { "markdown", "myst" },
 --     config = function()
 --       require('myst-markdown').setup()
 --     end,

--- a/lua/myst-markdown/highlighting.lua
+++ b/lua/myst-markdown/highlighting.lua
@@ -113,7 +113,9 @@ function M.refresh_active_buffers()
         end
         local start_ok, start_err = pcall(vim.treesitter.start, buf, "markdown")
         if not start_ok then
-          utils.debug("Failed to restart tree-sitter for buffer " .. buf .. ": " .. tostring(start_err))
+          utils.debug(
+            "Failed to restart tree-sitter for buffer " .. buf .. ": " .. tostring(start_err)
+          )
         else
           utils.debug("Refreshed tree-sitter highlighting for buffer " .. buf)
         end


### PR DESCRIPTION
## Problem

When using `ft = {"markdown", "myst"}` with lazy.nvim (our recommended config), the plugin loads lazily in response to a `FileType` event. By that time, nvim-treesitter has already started the markdown parser and **cached its injection queries without our `{code-cell}` patterns** (since our plugin wasn't in the runtimepath yet). The result: code-cell highlighting silently fails.

### Detailed execution flow (before this fix)

1. User opens `file.md` → Neovim detects `filetype=markdown`
2. nvim-treesitter starts the markdown parser → caches injection queries (our plugin is NOT in rtp)
3. lazy.nvim loads our plugin → adds to rtp → `setup()` runs → registers autocmds
4. lazy.nvim re-fires `doautocmd FileType` → our autocmd overrides to `myst` → `setup_treesitter()` starts tree-sitter, but with **stale cached queries** → no code-cell highlighting

### Related user report

A user also had a conflict with an old standalone `myst-markdown` plugin that further interfered with filetype detection and queries. A troubleshooting note has been added for this.

## Solution

### Code changes (`lua/myst-markdown/highlighting.lua`)

**`invalidate_query_cache()`** — Clears tree-sitter's cached markdown injection queries so they are re-read from the (now-updated) runtimepath. Uses `vim.treesitter.query.invalidate()` on Neovim >= 0.10, falls back to clearing internal cache tables on 0.9.

**`refresh_active_buffers()`** — Stops and restarts tree-sitter highlighting on open MyST buffers. After cache invalidation, this forces the `LanguageTree` to re-read queries with our injection patterns included.

**Late-loading detection in `setup_filetype_autocmd()`** — At setup time, checks if markdown/myst buffers are already open (indicating the plugin loaded late). If so, defers via `vim.schedule` to:
1. Invalidate the stale query cache
2. Re-detect filetypes for markdown buffers that may contain MyST content
3. Refresh tree-sitter highlighting with fresh queries

The `vim.schedule` deferral is important — it ensures the cache invalidation and refresh happen *after* lazy.nvim's synchronous `doautocmd FileType` completes, so we cleanly replace the stale tree-sitter state.

When no buffers are open (normal startup), this code is skipped entirely — zero overhead.

### Documentation changes

- Removed `priority = 1000` from all lazy.nvim examples (it has no effect on `ft`-loaded plugins)
- Added note explaining the plugin handles query cache invalidation automatically
- Added troubleshooting note about conflicts with old standalone `myst-markdown` plugins
- Added "Lazy loading issues" section to vim help docs
- Updated CHANGELOG

## Testing

All 175 tests pass (0 failures, 0 errors). Lint and format checks pass.
