### PR TITLE
docs: remove no-op priority=1000, add troubleshooting for plugin conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Removed `priority = 1000` from all lazy.nvim examples** — this setting is a no-op for
+  `ft`-based loading and was misleading; removed from README, examples, and help docs.
+- **Improved troubleshooting docs** — added guidance for conflicts with standalone `myst-markdown`
+  plugins and lazy loading issues.
+
 ## [0.5.1] - 2026-02-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
   config = function()
     require('myst-markdown').setup()
   end,
-  priority = 1000, -- Load after other markdown plugins
 }
 ```
 
@@ -54,14 +53,12 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
       },
     })
   end,
-  priority = 1000,
 }
 ```
 
 **Configuration Options Explained:**
 - `version = "0.5.1"` - Pin to a specific release for stability, or use `version = "*"` for latest
-- `ft = {"markdown", "myst"}` - Lazy loads the plugin only when opening markdown or MyST files, improving startup performance
-- `priority = 1000` - Ensures this plugin loads after other markdown plugins to prevent highlighting conflicts
+- `ft = {"markdown", "myst"}` - Lazy loads the plugin only when opening markdown or MyST files
 - `config` function - Runs the setup after treesitter is properly loaded
 
 ### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
@@ -93,7 +90,6 @@ To test unreleased changes from a specific branch (useful for testing fixes befo
     -- Ensure this runs after treesitter is loaded
     require('myst-markdown').setup()
   end,
-  priority = 1000, -- Load after other markdown plugins
 }
 ```
 
@@ -238,6 +234,9 @@ If MyST highlighting is not working:
 - Check if the language parser is installed: `:TSInstall <language>`
 - Example: For Python highlighting, run `:TSInstall python`
 - Verify parser is loaded: `:lua print(vim.inspect(require('nvim-treesitter.parsers').get_parser()))`
+
+**Conflicts with other MyST plugins?**
+- If you previously used a standalone `myst-markdown` plugin (not this one), remove it — it can conflict with `myst-markdown-tree-sitter.nvim`'s filetype detection and query injection
 
 **Math directive highlighting not working?**
 - Install the LaTeX parser: `:TSInstall latex`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This plugin provides syntax highlighting and filetype detection for [MyST (Marke
 **Configuration Options Explained:**
 - `version = "0.5.1"` - Pin to a specific release for stability, or use `version = "*"` for latest
 - `ft = {"markdown", "myst"}` - Lazy loads the plugin only when opening markdown or MyST files
-- `config` function - Runs the setup after treesitter is properly loaded
+- `config` function - Called when the plugin is loaded; assumes Tree-sitter is available via `dependencies`
 
 ### Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
@@ -236,7 +236,7 @@ If MyST highlighting is not working:
 - Verify parser is loaded: `:lua print(vim.inspect(require('nvim-treesitter.parsers').get_parser()))`
 
 **Conflicts with other MyST plugins?**
-- If you previously used a standalone `myst-markdown` plugin (not this one), remove it — it can conflict with `myst-markdown-tree-sitter.nvim`'s filetype detection and query injection
+- If you have another MyST plugin installed (e.g. `myst-markdown.nvim` without `tree-sitter` in the name), remove it — it can conflict with `myst-markdown-tree-sitter.nvim`'s filetype detection and query injection. Check via `:scriptnames` or `:echo &runtimepath`
 
 **Math directive highlighting not working?**
 - Install the LaTeX parser: `:TSInstall latex`

--- a/doc/myst-markdown.txt
+++ b/doc/myst-markdown.txt
@@ -60,7 +60,6 @@ Using lazy.nvim ~
       config = function()
         require('myst-markdown').setup()
       end,
-      priority = 1000,
     }
 <
 
@@ -273,9 +272,17 @@ Conflicts with other markdown plugins ~
 
 If experiencing conflicts:
 
-1. Set `priority = 1000` in lazy.nvim config to load after other plugins
-2. Ensure myst-markdown is loaded after other markdown-related plugins
+1. Remove any standalone `myst-markdown` plugin — it conflicts with this one
+2. Ensure myst-markdown-tree-sitter.nvim is loaded after other markdown plugins
 3. Check for duplicate filetype detections in other plugins
+
+Lazy loading issues ~
+
+If code-cell highlighting doesn't work with lazy.nvim:
+
+1. Ensure you are using `ft = {"markdown", "myst"}` in your plugin spec
+2. Run |:MystDebug| to verify injection queries are loaded
+3. If you previously used a standalone `myst-markdown` plugin, remove it
 
 Getting help ~
 

--- a/doc/myst-markdown.txt
+++ b/doc/myst-markdown.txt
@@ -272,17 +272,24 @@ Conflicts with other markdown plugins ~
 
 If experiencing conflicts:
 
-1. Remove any standalone `myst-markdown` plugin — it conflicts with this one
-2. Ensure myst-markdown-tree-sitter.nvim is loaded after other markdown plugins
-3. Check for duplicate filetype detections in other plugins
+1. Remove any other MyST plugin (e.g. `myst-markdown.nvim` without
+   `tree-sitter` in the name) — it conflicts with this one
+2. For lazy.nvim, ensure myst-markdown-tree-sitter.nvim loads after other
+   markdown plugins by listing them in the `dependencies` field or placing
+   its spec after theirs in your plugin list
+3. Check for duplicate filetype detections or markdown Tree-sitter query
+   overrides in other plugins
 
 Lazy loading issues ~
 
 If code-cell highlighting doesn't work with lazy.nvim:
 
 1. Ensure you are using `ft = {"markdown", "myst"}` in your plugin spec
-2. Run |:MystDebug| to verify injection queries are loaded
-3. If you previously used a standalone `myst-markdown` plugin, remove it
+2. If highlighting is missing, reload the buffer with `:edit` to force
+   Tree-sitter to re-read injection queries
+3. Run |:MystDebug| to verify injection queries are loaded
+4. If you have another MyST plugin installed (e.g. `myst-markdown.nvim`
+   without `tree-sitter` in the name), remove it
 
 Getting help ~
 

--- a/examples/lazy-nvim.lua
+++ b/examples/lazy-nvim.lua
@@ -12,9 +12,6 @@ return {
   -- Lazy load only for markdown and myst files
   ft = { "markdown", "myst" },
   
-  -- Load after other markdown plugins to prevent conflicts
-  priority = 1000,
-  
   -- Plugin configuration
   config = function()
     require('myst-markdown').setup({
@@ -56,7 +53,6 @@ return {
 --     'QuantEcon/myst-markdown-tree-sitter.nvim',
 --     dependencies = { 'nvim-treesitter/nvim-treesitter' },
 --     ft = { "markdown", "myst" },
---     priority = 1000,
 --     config = function()
 --       require('myst-markdown').setup()
 --     end,


### PR DESCRIPTION
## Summary

Documentation-only changes extracted from #74 (closed). No code changes.

## Changes

### Remove `priority = 1000` from lazy.nvim examples

`priority` only affects startup load order and has **no effect** on `ft`-loaded plugins (lazy.nvim ignores it when using `ft`-based triggers). Having it in our examples was misleading — users might think it's required or that it controls plugin ordering during ft-based loading. Removed from:

- README.md (basic setup, recommended setup, branch testing examples)
- doc/myst-markdown.txt (installation section)
- examples/lazy-nvim.lua (main spec and inline example)

### Add troubleshooting for plugin conflicts

A user reported broken highlighting that turned out to be caused by having an old standalone `myst-markdown` plugin installed alongside `myst-markdown-tree-sitter.nvim`. Added:

- **README.md**: New "Conflicts with other MyST plugins?" troubleshooting entry
- **doc/myst-markdown.txt**: Updated "Conflicts" section + new "Lazy loading issues" section

### Files changed

| File | Change |
|------|--------|
| README.md | Remove `priority = 1000`, update config explanation, add troubleshooting |
| doc/myst-markdown.txt | Remove `priority = 1000`, update conflicts, add lazy loading tips |
| examples/lazy-nvim.lua | Remove `priority = 1000` and related comments |
| CHANGELOG.md | Add entries under [Unreleased] |
