### PR TITLE
feat: add project website for GitHub Pages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -178,32 +178,34 @@ refactor: split highlighting logic into separate module
 ### GitHub CLI (`gh`) Usage
 **Important:** The `gh` CLI provides interactive results which can hang the terminal.
 
-**Always redirect output to `/tmp` when using `gh` commands:**
+**Always pipe output through `cat` or `head` when using `gh` commands:**
 
 ```bash
-# ✅ Good - Write to file first
-gh pr view 123 > /tmp/pr_details.txt
-cat /tmp/pr_details.txt
-
-gh issue list --limit 10 > /tmp/issues.txt
-cat /tmp/issues.txt
-
-# ❌ Bad - Will hang
-gh pr view 123
-gh issue list
+# ✅ Good - Pipe to avoid interactive pager
+gh pr view 123 2>&1 | cat
+gh issue list --limit 10 2>&1 | cat
 ```
 
-**When creating GitHub releases:**
+**When creating PRs or releases that need multi-line descriptions:**
+
+Use the `create_file` tool to write the body/notes to a file first, then reference it with `--body-file` or `--notes-file`. **Never** use heredocs, shell escaping, or inline multi-line strings in terminal commands — they are unreliable and error-prone.
 
 ```bash
-# ✅ Good - Simple version number only
+# ✅ Good - Use create_file tool to write /tmp/pr_body.md, then:
+gh pr create --title "feat: description" --body-file /tmp/pr_body.md --base main
+
+# ✅ Good - Use create_file tool to write /tmp/release_notes.md, then:
 gh release create v0.2.1 --title "v0.2.1" --notes-file /tmp/release_notes.md
 
-# ❌ Bad - Don't duplicate description in title
+# ❌ Bad - Heredocs and shell escaping break in terminal
+gh pr create --title "feat: thing" --body "## Summary
+Multi-line content here"
+
+# ❌ Bad - Don't duplicate description in release title
 gh release create v0.2.1 --title "v0.2.1 - Bug Fix: Description" --notes-file /tmp/release_notes.md
 ```
 
-**Rationale:** The title/description is already in the release notes file. Keep the GitHub release title clean with just the version number.
+**Rationale:** The `create_file` tool reliably writes exact content without escaping issues. Heredocs and multi-line shell strings frequently get mangled by the terminal. The title/description is already in the notes file — keep GitHub release titles clean with just the version number.
 
 ### Pull Request Guidelines
 - Write clear PR descriptions (what, why, how)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -236,6 +236,12 @@ gh release create v0.2.1 --title "v0.2.1 - Bug Fix: Description" --notes-file /t
 4. Write test case
 5. Update CHANGELOG.md
 
+### Releasing a New Version
+1. Update version in `lua/myst-markdown/version.lua` (single source of truth)
+2. Update `website/index.html` — version appears in the hero badge and installation example
+3. Move `[Unreleased]` entries in CHANGELOG.md to the new version heading
+4. Tag and create GitHub release
+
 ### Fixing Bugs
 1. Create test that reproduces the bug
 2. Fix the code

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,42 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/index.html
+++ b/website/index.html
@@ -50,15 +50,15 @@
       <div class="hero-code">
         <div class="code-window" data-theme="github-dark">
           <div class="code-window-bar">
-            <span class="code-dot red"></span>
-            <span class="code-dot yellow"></span>
-            <span class="code-dot green"></span>
+            <span class="code-dot red" aria-hidden="true"></span>
+            <span class="code-dot yellow" aria-hidden="true"></span>
+            <span class="code-dot green" aria-hidden="true"></span>
             <span class="code-window-title">example.md</span>
-            <div class="theme-tabs">
-              <button class="theme-tab active" data-theme-id="github-dark">GitHub Dark</button>
-              <button class="theme-tab" data-theme-id="catppuccin">Catppuccin</button>
-              <button class="theme-tab" data-theme-id="tokyonight">Tokyo Night</button>
-              <button class="theme-tab" data-theme-id="onedark">One Dark</button>
+            <div class="theme-tabs" role="group" aria-label="Color theme switcher">
+              <button class="theme-tab active" data-theme-id="github-dark" aria-label="Switch code preview to GitHub Dark theme">GitHub Dark</button>
+              <button class="theme-tab" data-theme-id="catppuccin" aria-label="Switch code preview to Catppuccin theme">Catppuccin</button>
+              <button class="theme-tab" data-theme-id="tokyonight" aria-label="Switch code preview to Tokyo Night theme">Tokyo Night</button>
+              <button class="theme-tab" data-theme-id="onedark" aria-label="Switch code preview to One Dark theme">One Dark</button>
             </div>
           </div>
           <pre class="code-block"><code><span class="c-comment"># MyST Markdown Example</span>

--- a/website/index.html
+++ b/website/index.html
@@ -48,12 +48,18 @@
         <a href="https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim" class="btn btn-secondary" target="_blank" rel="noopener">View on GitHub</a>
       </div>
       <div class="hero-code">
-        <div class="code-window">
+        <div class="code-window" data-theme="github-dark">
           <div class="code-window-bar">
             <span class="code-dot red"></span>
             <span class="code-dot yellow"></span>
             <span class="code-dot green"></span>
             <span class="code-window-title">example.md</span>
+            <div class="theme-tabs">
+              <button class="theme-tab active" data-theme-id="github-dark">GitHub Dark</button>
+              <button class="theme-tab" data-theme-id="catppuccin">Catppuccin</button>
+              <button class="theme-tab" data-theme-id="tokyonight">Tokyo Night</button>
+              <button class="theme-tab" data-theme-id="onedark">One Dark</button>
+            </div>
           </div>
           <pre class="code-block"><code><span class="c-comment"># MyST Markdown Example</span>
 

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,425 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>myst-markdown-tree-sitter.nvim — MyST Syntax Highlighting for Neovim</title>
+  <meta name="description" content="Tree-sitter powered syntax highlighting for MyST Markdown in Neovim. Code-cell directives, math blocks, and 10+ languages.">
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌿</text></svg>">
+</head>
+<body>
+  <!-- Navigation -->
+  <nav class="nav" id="nav">
+    <div class="nav-inner">
+      <a href="#" class="nav-logo">
+        <span class="nav-logo-icon">🌿</span>
+        <span class="nav-logo-text">MyST for Neovim</span>
+      </a>
+      <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav-links" id="nav-links">
+        <li><a href="#features">Features</a></li>
+        <li><a href="#installation">Install</a></li>
+        <li><a href="#configuration">Config</a></li>
+        <li><a href="#languages">Languages</a></li>
+        <li><a href="#commands">Commands</a></li>
+        <li><a href="#troubleshooting">Help</a></li>
+        <li><a href="https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim" class="nav-github" target="_blank" rel="noopener">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        </a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Hero -->
+  <header class="hero">
+    <div class="hero-bg-glow"></div>
+    <div class="container">
+      <div class="hero-badge">v0.5.1 · Neovim Plugin</div>
+      <h1 class="hero-title">
+        <span class="hero-title-myst">myst-markdown</span><br>
+        <span class="hero-title-ts">tree-sitter</span><span class="hero-title-nvim">.nvim</span>
+      </h1>
+      <p class="hero-subtitle">Tree-sitter powered syntax highlighting for <a href="https://mystmd.org/" target="_blank" rel="noopener">MyST Markdown</a> in Neovim.<br>Code-cell directives, math blocks, and 10+ language injections.</p>
+      <div class="hero-actions">
+        <a href="#installation" class="btn btn-primary">Get Started</a>
+        <a href="https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim" class="btn btn-secondary" target="_blank" rel="noopener">View on GitHub</a>
+      </div>
+      <div class="hero-code">
+        <div class="code-window">
+          <div class="code-window-bar">
+            <span class="code-dot red"></span>
+            <span class="code-dot yellow"></span>
+            <span class="code-dot green"></span>
+            <span class="code-window-title">example.md</span>
+          </div>
+          <pre class="code-block"><code><span class="c-comment"># MyST Markdown Example</span>
+
+<span class="c-directive">```{code-cell}</span> <span class="c-lang">python</span>
+<span class="c-keyword">import</span> <span class="c-module">pandas</span> <span class="c-keyword">as</span> <span class="c-module">pd</span>
+
+<span class="c-var">df</span> <span class="c-op">=</span> <span class="c-module">pd</span>.<span class="c-func">DataFrame</span>({
+    <span class="c-string">"x"</span>: [<span class="c-number">1</span>, <span class="c-number">2</span>, <span class="c-number">3</span>],
+    <span class="c-string">"y"</span>: [<span class="c-number">4</span>, <span class="c-number">5</span>, <span class="c-number">6</span>]
+})
+<span class="c-func">print</span>(<span class="c-var">df</span>)
+<span class="c-directive">```</span>
+
+<span class="c-directive">```{math}</span>
+<span class="c-math">\begin{aligned}</span>
+    <span class="c-math">E &= mc^2 \\</span>
+    <span class="c-math">F &= ma</span>
+<span class="c-math">\end{aligned}</span>
+<span class="c-directive">```</span></code></pre>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- Features -->
+  <section class="section" id="features">
+    <div class="container">
+      <h2 class="section-title">Features</h2>
+      <p class="section-subtitle">Everything you need for MyST Markdown editing in Neovim</p>
+      <div class="features-grid">
+        <div class="feature-card">
+          <div class="feature-icon">🔍</div>
+          <h3>Auto Detection</h3>
+          <p>Automatically detects MyST files based on content patterns like <code>{code-cell}</code> and <code>{math}</code> directives.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🎨</div>
+          <h3>Code-Cell Highlighting</h3>
+          <p>Language-specific syntax highlighting inside <code>{code-cell}</code> directives — Python, JavaScript, Bash, and more.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">📐</div>
+          <h3>Math Directives</h3>
+          <p>Full LaTeX syntax highlighting for <code>{math}</code> directives and <code>$$</code> blocks.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🌳</div>
+          <h3>Tree-sitter Powered</h3>
+          <p>Built on tree-sitter for robust, accurate parsing. Uses injection queries for language-specific highlighting.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">⚡</div>
+          <h3>Fast & Lightweight</h3>
+          <p>Detection caching, configurable scan limits, and zero-cost debug logging when disabled.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🧪</div>
+          <h3>170+ Tests</h3>
+          <p>Comprehensive test suite covering directives, edge cases, performance, and tree-sitter integration.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Installation -->
+  <section class="section section-alt" id="installation">
+    <div class="container">
+      <h2 class="section-title">Installation</h2>
+      <p class="section-subtitle">Get up and running in minutes</p>
+
+      <div class="install-tabs">
+        <button class="tab-btn active" data-tab="lazy">lazy.nvim</button>
+        <button class="tab-btn" data-tab="packer">packer.nvim</button>
+      </div>
+
+      <div class="tab-content active" id="tab-lazy">
+        <div class="code-window">
+          <div class="code-window-bar">
+            <span class="code-dot red"></span>
+            <span class="code-dot yellow"></span>
+            <span class="code-dot green"></span>
+            <span class="code-window-title">plugins/myst.lua</span>
+          </div>
+          <pre class="code-block"><code>{
+  <span class="c-string">"QuantEcon/myst-markdown-tree-sitter.nvim"</span>,
+  <span class="c-var">version</span> = <span class="c-string">"0.5.1"</span>,
+  <span class="c-var">dependencies</span> = { <span class="c-string">"nvim-treesitter/nvim-treesitter"</span> },
+  <span class="c-var">ft</span> = { <span class="c-string">"markdown"</span>, <span class="c-string">"myst"</span> },
+  <span class="c-var">config</span> = <span class="c-keyword">function</span>()
+    <span class="c-func">require</span>(<span class="c-string">'myst-markdown'</span>).<span class="c-func">setup</span>()
+  <span class="c-keyword">end</span>,
+}</code></pre>
+        </div>
+      </div>
+
+      <div class="tab-content" id="tab-packer">
+        <div class="code-window">
+          <div class="code-window-bar">
+            <span class="code-dot red"></span>
+            <span class="code-dot yellow"></span>
+            <span class="code-dot green"></span>
+            <span class="code-window-title">plugins.lua</span>
+          </div>
+          <pre class="code-block"><code><span class="c-func">use</span> {
+  <span class="c-string">'QuantEcon/myst-markdown-tree-sitter.nvim'</span>,
+  <span class="c-var">requires</span> = {<span class="c-string">'nvim-treesitter/nvim-treesitter'</span>},
+  <span class="c-var">config</span> = <span class="c-keyword">function</span>()
+    <span class="c-func">require</span>(<span class="c-string">'myst-markdown'</span>).<span class="c-func">setup</span>()
+  <span class="c-keyword">end</span>
+}</code></pre>
+        </div>
+      </div>
+
+      <div class="install-requirements">
+        <h3>Requirements</h3>
+        <ul>
+          <li><strong>Neovim</strong> &ge; 0.8.0</li>
+          <li><a href="https://github.com/nvim-treesitter/nvim-treesitter" target="_blank" rel="noopener">nvim-treesitter</a></li>
+          <li>Tree-sitter parsers: <code>:TSInstall markdown markdown_inline</code></li>
+          <li>Recommended: <code>:TSInstall python latex</code></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- Configuration -->
+  <section class="section" id="configuration">
+    <div class="container">
+      <h2 class="section-title">Configuration</h2>
+      <p class="section-subtitle">Works out of the box — customize when you need to</p>
+
+      <div class="config-grid">
+        <div class="config-block">
+          <h3>Minimal (recommended)</h3>
+          <div class="code-window">
+            <div class="code-window-bar">
+              <span class="code-dot red"></span>
+              <span class="code-dot yellow"></span>
+              <span class="code-dot green"></span>
+            </div>
+            <pre class="code-block"><code><span class="c-func">require</span>(<span class="c-string">'myst-markdown'</span>).<span class="c-func">setup</span>()</code></pre>
+          </div>
+        </div>
+        <div class="config-block">
+          <h3>Full options</h3>
+          <div class="code-window">
+            <div class="code-window-bar">
+              <span class="code-dot red"></span>
+              <span class="code-dot yellow"></span>
+              <span class="code-dot green"></span>
+            </div>
+            <pre class="code-block"><code><span class="c-func">require</span>(<span class="c-string">'myst-markdown'</span>).<span class="c-func">setup</span>({
+  <span class="c-var">debug</span> = <span class="c-keyword">false</span>,
+  <span class="c-var">detection</span> = {
+    <span class="c-var">scan_lines</span> = <span class="c-number">50</span>,
+  },
+  <span class="c-var">performance</span> = {
+    <span class="c-var">cache_enabled</span> = <span class="c-keyword">true</span>,
+  },
+  <span class="c-var">highlighting</span> = {
+    <span class="c-var">enabled</span> = <span class="c-keyword">true</span>,
+  },
+})</code></pre>
+          </div>
+        </div>
+      </div>
+
+      <div class="config-table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr>
+              <th>Option</th>
+              <th>Default</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>debug</code></td>
+              <td><code>false</code></td>
+              <td>Enable verbose debug logging</td>
+            </tr>
+            <tr>
+              <td><code>detection.scan_lines</code></td>
+              <td><code>50</code></td>
+              <td>Lines to scan for MyST patterns</td>
+            </tr>
+            <tr>
+              <td><code>performance.cache_enabled</code></td>
+              <td><code>true</code></td>
+              <td>Cache filetype detection results</td>
+            </tr>
+            <tr>
+              <td><code>highlighting.enabled</code></td>
+              <td><code>true</code></td>
+              <td>Enable tree-sitter highlighting</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- Supported Languages -->
+  <section class="section section-alt" id="languages">
+    <div class="container">
+      <h2 class="section-title">Supported Languages</h2>
+      <p class="section-subtitle">Language injection for <code>{code-cell}</code> directives</p>
+
+      <div class="lang-grid">
+        <div class="lang-card lang-featured">
+          <div class="lang-name">Python</div>
+          <div class="lang-aliases">python, python3, ipython, ipython3</div>
+          <div class="lang-badge">Built-in</div>
+        </div>
+        <div class="lang-card lang-featured">
+          <div class="lang-name">LaTeX</div>
+          <div class="lang-aliases">{math} directives</div>
+          <div class="lang-badge">Recommended</div>
+        </div>
+        <div class="lang-card">
+          <div class="lang-name">JavaScript</div>
+          <div class="lang-aliases">javascript, js</div>
+        </div>
+        <div class="lang-card">
+          <div class="lang-name">TypeScript</div>
+          <div class="lang-aliases">typescript, ts</div>
+        </div>
+        <div class="lang-card">
+          <div class="lang-name">Bash</div>
+          <div class="lang-aliases">bash, sh</div>
+        </div>
+        <div class="lang-card">
+          <div class="lang-name">R</div>
+          <div class="lang-aliases">r</div>
+        </div>
+        <div class="lang-card">
+          <div class="lang-name">Julia</div>
+          <div class="lang-aliases">julia</div>
+        </div>
+        <div class="lang-card">
+          <div class="lang-name">Rust</div>
+          <div class="lang-aliases">rust</div>
+        </div>
+        <div class="lang-card">
+          <div class="lang-name">Go</div>
+          <div class="lang-aliases">go</div>
+        </div>
+        <div class="lang-card">
+          <div class="lang-name">C / C++</div>
+          <div class="lang-aliases">c, cpp</div>
+        </div>
+      </div>
+
+      <p class="lang-install-hint">Install parsers with <code>:TSInstall &lt;language&gt;</code></p>
+    </div>
+  </section>
+
+  <!-- Commands -->
+  <section class="section" id="commands">
+    <div class="container">
+      <h2 class="section-title">Commands</h2>
+      <p class="section-subtitle">Built-in commands for debugging and diagnostics</p>
+
+      <div class="commands-grid">
+        <div class="command-card">
+          <div class="command-name"><code>:MystStatus</code></div>
+          <p>Quick health check of MyST highlighting status for the current buffer.</p>
+        </div>
+        <div class="command-card">
+          <div class="command-name"><code>:MystDebug</code></div>
+          <p>Comprehensive debugging info — tree-sitter state, queries, injections, diagnostics.</p>
+        </div>
+        <div class="command-card">
+          <div class="command-name"><code>:MystInfo</code></div>
+          <p>Show plugin version, configuration, and environment details.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Troubleshooting -->
+  <section class="section section-alt" id="troubleshooting">
+    <div class="container">
+      <h2 class="section-title">Troubleshooting</h2>
+      <p class="section-subtitle">Quick fixes for common issues</p>
+
+      <div class="faq-list">
+        <details class="faq-item">
+          <summary>Highlighting not working at all</summary>
+          <div class="faq-answer">
+            <ol>
+              <li>Run <code>:MystStatus</code> for a quick health check</li>
+              <li>Ensure the file contains MyST directives like <code>{code-cell}</code> or <code>{math}</code></li>
+              <li>Verify nvim-treesitter is installed and the markdown parser is available</li>
+              <li>Run <code>:MystDebug</code> for detailed diagnostics</li>
+            </ol>
+          </div>
+        </details>
+        <details class="faq-item">
+          <summary>Code-cell highlighting not working for a specific language</summary>
+          <div class="faq-answer">
+            <p>The tree-sitter parser for that language may not be installed.</p>
+            <pre class="code-inline">:TSInstall python    <span class="c-comment">-- or javascript, bash, etc.</span></pre>
+            <p>Verify with <code>:TSInstallInfo</code> to see installed parsers.</p>
+          </div>
+        </details>
+        <details class="faq-item">
+          <summary>Conflicts with other MyST plugins</summary>
+          <div class="faq-answer">
+            <p>If you have another MyST plugin installed (e.g., <code>myst-markdown.nvim</code> without <code>tree-sitter</code> in the name), remove it — it can conflict with filetype detection and query injection.</p>
+            <p>Check via <code>:scriptnames</code> or <code>:echo &amp;runtimepath</code>.</p>
+          </div>
+        </details>
+        <details class="faq-item">
+          <summary>Math directive highlighting not working</summary>
+          <div class="faq-answer">
+            <p>Install the LaTeX tree-sitter parser:</p>
+            <pre class="code-inline">:TSInstall latex</pre>
+          </div>
+        </details>
+        <details class="faq-item">
+          <summary>Colon-fence directives not highlighted</summary>
+          <div class="faq-answer">
+            <p>MyST supports both backtick fences (<code>```</code>) and colon fences (<code>:::</code>), but this plugin only supports backtick fences because the underlying markdown tree-sitter parser doesn't recognize colon fences.</p>
+            <p>See <a href="https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim/issues/51" target="_blank" rel="noopener">issue #51</a> for tracking a dedicated MyST parser.</p>
+          </div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-about">
+          <div class="footer-logo">🌿 myst-markdown-tree-sitter.nvim</div>
+          <p>Tree-sitter syntax highlighting for MyST Markdown in Neovim.</p>
+          <p class="footer-org">Built by <a href="https://quantecon.org" target="_blank" rel="noopener">QuantEcon</a></p>
+        </div>
+        <div class="footer-links-section">
+          <h4>Resources</h4>
+          <ul>
+            <li><a href="https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
+            <li><a href="https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
+            <li><a href="https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim/issues" target="_blank" rel="noopener">Issues</a></li>
+          </ul>
+        </div>
+        <div class="footer-links-section">
+          <h4>Ecosystem</h4>
+          <ul>
+            <li><a href="https://mystmd.org/" target="_blank" rel="noopener">MyST Markdown</a></li>
+            <li><a href="https://neovim.io/" target="_blank" rel="noopener">Neovim</a></li>
+            <li><a href="https://github.com/nvim-treesitter/nvim-treesitter" target="_blank" rel="noopener">nvim-treesitter</a></li>
+            <li><a href="https://quantecon.org" target="_blank" rel="noopener">QuantEcon</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>MIT License &copy; 2026 QuantEcon</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -68,10 +68,10 @@
 <span class="c-directive">```</span>
 
 <span class="c-directive">```{math}</span>
-<span class="c-math">\begin{aligned}</span>
-    <span class="c-math">E &= mc^2 \\</span>
-    <span class="c-math">F &= ma</span>
-<span class="c-math">\end{aligned}</span>
+<span class="c-tex-cmd">\begin</span><span class="c-tex-brace">{</span><span class="c-tex-env">aligned</span><span class="c-tex-brace">}</span>
+    <span class="c-tex-var">E</span> <span class="c-tex-op">&amp;=</span> <span class="c-tex-var">mc</span><span class="c-tex-sup">^2</span> <span class="c-tex-op">\\</span>
+    <span class="c-tex-var">F</span> <span class="c-tex-op">&amp;=</span> <span class="c-tex-var">ma</span>
+<span class="c-tex-cmd">\end</span><span class="c-tex-brace">{</span><span class="c-tex-env">aligned</span><span class="c-tex-brace">}</span>
 <span class="c-directive">```</span></code></pre>
         </div>
       </div>

--- a/website/index.html
+++ b/website/index.html
@@ -6,14 +6,14 @@
   <title>myst-markdown-tree-sitter.nvim — MyST Syntax Highlighting for Neovim</title>
   <meta name="description" content="Tree-sitter powered syntax highlighting for MyST Markdown in Neovim. Code-cell directives, math blocks, and 10+ languages.">
   <link rel="stylesheet" href="style.css">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌿</text></svg>">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect rx='16' width='100' height='100' fill='%230d1117'/><text x='50' y='58' font-family='monospace' font-size='52' font-weight='bold' fill='%237ee787' text-anchor='middle' dominant-baseline='middle'>&lt;/&gt;</text></svg>">
 </head>
 <body>
   <!-- Navigation -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
       <a href="#" class="nav-logo">
-        <span class="nav-logo-icon">🌿</span>
+        <span class="nav-logo-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7 8L3 12L7 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M17 8L21 12L17 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 4L10 20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></span>
         <span class="nav-logo-text">MyST for Neovim</span>
       </a>
       <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu">
@@ -397,7 +397,7 @@
     <div class="container">
       <div class="footer-grid">
         <div class="footer-about">
-          <div class="footer-logo">🌿 myst-markdown-tree-sitter.nvim</div>
+          <div class="footer-logo"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style="vertical-align: -3px; margin-right: 6px;"><path d="M7 8L3 12L7 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M17 8L21 12L17 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 4L10 20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>myst-markdown-tree-sitter.nvim</div>
           <p>Tree-sitter syntax highlighting for MyST Markdown in Neovim.</p>
           <p class="footer-org">Built by <a href="https://quantecon.org" target="_blank" rel="noopener">QuantEcon</a></p>
         </div>

--- a/website/script.js
+++ b/website/script.js
@@ -43,6 +43,23 @@
     });
   });
 
+  // --- Hero theme switcher ---
+  const themeTabs = document.querySelectorAll('.theme-tab');
+  const heroCodeWindow = document.querySelector('.hero-code .code-window');
+
+  themeTabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      const themeId = tab.getAttribute('data-theme-id');
+
+      themeTabs.forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+
+      if (heroCodeWindow) {
+        heroCodeWindow.setAttribute('data-theme', themeId);
+      }
+    });
+  });
+
   // --- Scroll reveal ---
   const revealElements = () => {
     // Apply reveal class to section elements

--- a/website/script.js
+++ b/website/script.js
@@ -122,10 +122,16 @@
   handleScroll();
   updateNavBg();
 
+  let isScrolling = false;
   window.addEventListener('scroll', () => {
-    handleScroll();
-    updateActiveNav();
-    updateNavBg();
+    if (isScrolling) return;
+    isScrolling = true;
+    requestAnimationFrame(() => {
+      handleScroll();
+      updateActiveNav();
+      updateNavBg();
+      isScrolling = false;
+    });
   }, { passive: true });
 
   // --- Smooth scroll for anchor links (fallback for older browsers) ---

--- a/website/script.js
+++ b/website/script.js
@@ -1,0 +1,129 @@
+/* ============================================
+   myst-markdown-tree-sitter.nvim — Website JS
+   Minimal interactions: nav toggle, tabs,
+   smooth scroll, scroll reveal
+   ============================================ */
+
+(function () {
+  'use strict';
+
+  // --- Mobile nav toggle ---
+  const navToggle = document.getElementById('nav-toggle');
+  const navLinks = document.getElementById('nav-links');
+
+  if (navToggle && navLinks) {
+    navToggle.addEventListener('click', () => {
+      navLinks.classList.toggle('open');
+      navToggle.classList.toggle('active');
+    });
+
+    // Close mobile nav when clicking a link
+    navLinks.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        navLinks.classList.remove('open');
+        navToggle.classList.remove('active');
+      });
+    });
+  }
+
+  // --- Installation tabs ---
+  const tabBtns = document.querySelectorAll('.tab-btn');
+  const tabContents = document.querySelectorAll('.tab-content');
+
+  tabBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = btn.getAttribute('data-tab');
+
+      tabBtns.forEach(b => b.classList.remove('active'));
+      tabContents.forEach(c => c.classList.remove('active'));
+
+      btn.classList.add('active');
+      const targetEl = document.getElementById('tab-' + target);
+      if (targetEl) targetEl.classList.add('active');
+    });
+  });
+
+  // --- Scroll reveal ---
+  const revealElements = () => {
+    // Apply reveal class to section elements
+    const sections = document.querySelectorAll(
+      '.feature-card, .command-card, .lang-card, .config-block, .install-requirements, .faq-item'
+    );
+    sections.forEach(el => {
+      if (!el.classList.contains('reveal')) {
+        el.classList.add('reveal');
+      }
+    });
+  };
+
+  const handleScroll = () => {
+    const reveals = document.querySelectorAll('.reveal');
+    const windowHeight = window.innerHeight;
+
+    reveals.forEach(el => {
+      const top = el.getBoundingClientRect().top;
+      if (top < windowHeight - 60) {
+        el.classList.add('visible');
+      }
+    });
+  };
+
+  // --- Active nav link highlighting ---
+  const updateActiveNav = () => {
+    const sections = document.querySelectorAll('section[id]');
+    const navAnchors = document.querySelectorAll('.nav-links a[href^="#"]');
+    let current = '';
+
+    sections.forEach(section => {
+      const top = section.getBoundingClientRect().top;
+      if (top <= 120) {
+        current = section.getAttribute('id');
+      }
+    });
+
+    navAnchors.forEach(a => {
+      a.classList.remove('active');
+      if (a.getAttribute('href') === '#' + current) {
+        a.classList.add('active');
+      }
+    });
+  };
+
+  // --- Nav background on scroll ---
+  const nav = document.getElementById('nav');
+  const updateNavBg = () => {
+    if (!nav) return;
+    if (window.scrollY > 20) {
+      nav.style.borderBottomColor = 'var(--border-default)';
+    } else {
+      nav.style.borderBottomColor = 'transparent';
+    }
+  };
+
+  // --- Initialize ---
+  revealElements();
+  handleScroll();
+  updateNavBg();
+
+  window.addEventListener('scroll', () => {
+    handleScroll();
+    updateActiveNav();
+    updateNavBg();
+  }, { passive: true });
+
+  // --- Smooth scroll for anchor links (fallback for older browsers) ---
+  document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    anchor.addEventListener('click', (e) => {
+      const href = anchor.getAttribute('href');
+      if (href === '#') return;
+
+      const target = document.querySelector(href);
+      if (target) {
+        e.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth' });
+        // Update URL without jumping
+        history.pushState(null, null, href);
+      }
+    });
+  });
+})();

--- a/website/style.css
+++ b/website/style.css
@@ -161,7 +161,9 @@ ul {
 }
 
 .nav-logo-icon {
-  font-size: 1.4rem;
+  display: flex;
+  align-items: center;
+  color: var(--accent-green);
 }
 
 .nav-links {

--- a/website/style.css
+++ b/website/style.css
@@ -348,10 +348,11 @@ ul {
    Code Window
    =========================== */
 .code-window {
-  background: var(--bg-code);
+  background: var(--cw-bg, var(--bg-code));
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   overflow: hidden;
+  transition: background 0.3s ease;
 }
 
 .code-window-bar {
@@ -359,8 +360,10 @@ ul {
   align-items: center;
   gap: 6px;
   padding: 10px 14px;
-  background: var(--bg-elevated);
+  background: var(--cw-bar, var(--bg-elevated));
   border-bottom: 1px solid var(--border-default);
+  flex-wrap: wrap;
+  transition: background 0.3s ease;
 }
 
 .code-dot {
@@ -380,14 +383,48 @@ ul {
   font-family: var(--font-sans);
 }
 
+/* --- Theme Tabs --- */
+.theme-tabs {
+  display: flex;
+  gap: 2px;
+  margin-left: auto;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.theme-tab {
+  padding: 3px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 500;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.theme-tab:hover {
+  color: var(--text-secondary);
+}
+
+.theme-tab.active {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
 .code-block {
   padding: var(--space-lg);
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: 0.85rem;
   line-height: 1.65;
-  color: var(--text-primary);
+  color: var(--cw-fg, var(--text-primary));
   tab-size: 4;
+  transition: color 0.3s ease;
 }
 
 .code-block code {
@@ -397,26 +434,102 @@ ul {
   color: inherit;
 }
 
-/* Syntax highlighting classes */
-.c-keyword { color: var(--syn-keyword); }
-.c-string { color: var(--syn-string); }
-.c-func { color: var(--syn-func); }
-.c-number { color: var(--syn-number); }
-.c-comment { color: var(--syn-comment); }
-.c-var { color: var(--syn-var); }
-.c-module { color: var(--syn-module); }
-.c-op { color: var(--syn-op); }
-.c-directive { color: var(--syn-directive); font-weight: 600; }
-.c-lang { color: var(--syn-lang); font-weight: 600; }
-.c-math { color: var(--syn-math); }
+/* Syntax highlighting — uses code-window scoped vars with fallback */
+.c-keyword { color: var(--cw-keyword, var(--syn-keyword)); transition: color 0.3s ease; }
+.c-string { color: var(--cw-string, var(--syn-string)); transition: color 0.3s ease; }
+.c-func { color: var(--cw-func, var(--syn-func)); transition: color 0.3s ease; }
+.c-number { color: var(--cw-number, var(--syn-number)); transition: color 0.3s ease; }
+.c-comment { color: var(--cw-comment, var(--syn-comment)); transition: color 0.3s ease; }
+.c-var { color: var(--cw-var, var(--syn-var)); transition: color 0.3s ease; }
+.c-module { color: var(--cw-module, var(--syn-module)); transition: color 0.3s ease; }
+.c-op { color: var(--cw-op, var(--syn-op)); transition: color 0.3s ease; }
+.c-directive { color: var(--cw-directive, var(--syn-directive)); font-weight: 600; transition: color 0.3s ease; }
+.c-lang { color: var(--cw-lang, var(--syn-lang)); font-weight: 600; transition: color 0.3s ease; }
+.c-math { color: var(--cw-math, var(--syn-math)); transition: color 0.3s ease; }
 
-/* LaTeX syntax */
-.c-tex-cmd { color: #d2a8ff; }        /* \begin, \end — purple, like functions */
-.c-tex-brace { color: #8b949e; }      /* { } — muted gray */
-.c-tex-env { color: #7ee787; }        /* aligned — green, like identifiers */
-.c-tex-var { color: #e6edf3; }        /* E, F, mc, ma — primary text */
-.c-tex-op { color: #ff7b72; }         /* &=, \\, ^  — red, like operators */
-.c-tex-sup { color: #79c0ff; }        /* ^2 — blue, like numbers */
+/* LaTeX syntax — also theme-aware */
+.c-tex-cmd { color: var(--cw-func, #d2a8ff); transition: color 0.3s ease; }
+.c-tex-brace { color: var(--cw-comment, #8b949e); transition: color 0.3s ease; }
+.c-tex-env { color: var(--cw-module, #7ee787); transition: color 0.3s ease; }
+.c-tex-var { color: var(--cw-fg, #e6edf3); transition: color 0.3s ease; }
+.c-tex-op { color: var(--cw-op, #ff7b72); transition: color 0.3s ease; }
+.c-tex-sup { color: var(--cw-number, #79c0ff); transition: color 0.3s ease; }
+
+/* ===========================
+   Theme Palettes
+   =========================== */
+
+/* GitHub Dark (default) */
+.code-window[data-theme="github-dark"] {
+  --cw-bg: #0d1117;
+  --cw-bar: #161b22;
+  --cw-fg: #e6edf3;
+  --cw-keyword: #ff7b72;
+  --cw-string: #a5d6ff;
+  --cw-func: #d2a8ff;
+  --cw-number: #79c0ff;
+  --cw-comment: #8b949e;
+  --cw-var: #ffa657;
+  --cw-module: #7ee787;
+  --cw-op: #ff7b72;
+  --cw-directive: #bc8cff;
+  --cw-lang: #7ee787;
+  --cw-math: #a5d6ff;
+}
+
+/* Catppuccin Mocha */
+.code-window[data-theme="catppuccin"] {
+  --cw-bg: #1e1e2e;
+  --cw-bar: #181825;
+  --cw-fg: #cdd6f4;
+  --cw-keyword: #cba6f7;
+  --cw-string: #a6e3a1;
+  --cw-func: #89b4fa;
+  --cw-number: #fab387;
+  --cw-comment: #6c7086;
+  --cw-var: #f38ba8;
+  --cw-module: #f9e2af;
+  --cw-op: #89dceb;
+  --cw-directive: #cba6f7;
+  --cw-lang: #a6e3a1;
+  --cw-math: #89b4fa;
+}
+
+/* Tokyo Night */
+.code-window[data-theme="tokyonight"] {
+  --cw-bg: #1a1b26;
+  --cw-bar: #16161e;
+  --cw-fg: #c0caf5;
+  --cw-keyword: #bb9af7;
+  --cw-string: #9ece6a;
+  --cw-func: #7aa2f7;
+  --cw-number: #ff9e64;
+  --cw-comment: #565f89;
+  --cw-var: #c0caf5;
+  --cw-module: #2ac3de;
+  --cw-op: #89ddff;
+  --cw-directive: #bb9af7;
+  --cw-lang: #9ece6a;
+  --cw-math: #7aa2f7;
+}
+
+/* One Dark */
+.code-window[data-theme="onedark"] {
+  --cw-bg: #282c34;
+  --cw-bar: #21252b;
+  --cw-fg: #abb2bf;
+  --cw-keyword: #c678dd;
+  --cw-string: #98c379;
+  --cw-func: #61afef;
+  --cw-number: #d19a66;
+  --cw-comment: #5c6370;
+  --cw-var: #e06c75;
+  --cw-module: #e5c07b;
+  --cw-op: #56b6c2;
+  --cw-directive: #c678dd;
+  --cw-lang: #98c379;
+  --cw-math: #61afef;
+}
 
 /* Inline code blocks (for troubleshooting) */
 .code-inline {
@@ -943,6 +1056,21 @@ ul {
 
   .hero-code {
     margin: 0 calc(-1 * var(--space-md));
+  }
+
+  .theme-tabs {
+    margin-left: 0;
+    margin-top: 6px;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .code-window-bar {
+    justify-content: flex-start;
+  }
+
+  .code-window-title {
+    flex: 1;
   }
 
   .lang-grid {

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,982 @@
+/* ============================================
+   myst-markdown-tree-sitter.nvim — Website
+   Dark theme with Neovim/MyST-inspired colors
+   ============================================ */
+
+/* --- Design Tokens --- */
+:root {
+  /* Core palette */
+  --bg-deep: #0d1117;
+  --bg-primary: #161b22;
+  --bg-secondary: #1c2129;
+  --bg-elevated: #21262d;
+  --bg-code: #0d1117;
+
+  /* Accent colors — Neovim green + MyST purple */
+  --accent-green: #7ee787;
+  --accent-green-dim: #3fb950;
+  --accent-purple: #bc8cff;
+  --accent-purple-dim: #8b5cf6;
+  --accent-blue: #58a6ff;
+
+  /* Text */
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #6e7681;
+  --text-link: #58a6ff;
+
+  /* Borders */
+  --border-default: #30363d;
+  --border-muted: #21262d;
+
+  /* Code syntax colors */
+  --syn-keyword: #ff7b72;
+  --syn-string: #a5d6ff;
+  --syn-func: #d2a8ff;
+  --syn-number: #79c0ff;
+  --syn-comment: #8b949e;
+  --syn-var: #ffa657;
+  --syn-module: #7ee787;
+  --syn-op: #ff7b72;
+  --syn-directive: #bc8cff;
+  --syn-lang: #7ee787;
+  --syn-math: #a5d6ff;
+
+  /* Spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+  --space-3xl: 4rem;
+  --space-4xl: 6rem;
+
+  /* Typography */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', Menlo, monospace;
+
+  /* Misc */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --transition: 0.2s ease;
+  --max-width: 1120px;
+}
+
+/* --- Reset & Base --- */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 80px;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-deep);
+  color: var(--text-primary);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--text-link);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+a:hover {
+  color: var(--accent-green);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: var(--bg-elevated);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  color: var(--accent-purple);
+}
+
+img {
+  max-width: 100%;
+}
+
+ul {
+  list-style: none;
+}
+
+/* --- Container --- */
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 var(--space-lg);
+}
+
+/* ===========================
+   Navigation
+   =========================== */
+.nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: rgba(13, 17, 23, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-default);
+  transition: background var(--transition);
+}
+
+.nav-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 var(--space-lg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+}
+
+.nav-logo {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.nav-logo:hover {
+  color: var(--accent-green);
+}
+
+.nav-logo-icon {
+  font-size: 1.4rem;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+}
+
+.nav-links a {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: color var(--transition);
+}
+
+.nav-links a:hover {
+  color: var(--text-primary);
+}
+
+.nav-github {
+  display: flex;
+  align-items: center;
+  color: var(--text-secondary) !important;
+}
+
+.nav-github:hover {
+  color: var(--text-primary) !important;
+}
+
+/* Mobile nav toggle */
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--text-secondary);
+  border-radius: 2px;
+  transition: all var(--transition);
+}
+
+/* ===========================
+   Hero
+   =========================== */
+.hero {
+  position: relative;
+  padding: calc(64px + var(--space-4xl)) 0 var(--space-4xl);
+  text-align: center;
+  overflow: hidden;
+}
+
+.hero-bg-glow {
+  position: absolute;
+  top: -200px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 800px;
+  height: 600px;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(126, 231, 135, 0.08) 0%,
+    rgba(188, 140, 255, 0.05) 40%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+.hero-badge {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--accent-green);
+  background: rgba(126, 231, 135, 0.1);
+  border: 1px solid rgba(126, 231, 135, 0.2);
+  padding: 0.35em 1em;
+  border-radius: 999px;
+  margin-bottom: var(--space-xl);
+  letter-spacing: 0.02em;
+}
+
+.hero-title {
+  font-size: clamp(2.2rem, 6vw, 3.8rem);
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  margin-bottom: var(--space-lg);
+}
+
+.hero-title-myst {
+  color: var(--accent-purple);
+}
+
+.hero-title-ts {
+  color: var(--accent-green);
+}
+
+.hero-title-nvim {
+  color: var(--text-secondary);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto var(--space-2xl);
+  line-height: 1.7;
+}
+
+.hero-subtitle a {
+  color: var(--accent-purple);
+  text-decoration: underline;
+  text-decoration-color: rgba(188, 140, 255, 0.3);
+  text-underline-offset: 3px;
+}
+
+.hero-subtitle a:hover {
+  text-decoration-color: var(--accent-purple);
+}
+
+.hero-actions {
+  display: flex;
+  gap: var(--space-md);
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3xl);
+}
+
+/* --- Buttons --- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 0.7em 1.6em;
+  border-radius: var(--radius-md);
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: all var(--transition);
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--accent-green-dim);
+  color: #fff;
+  border-color: var(--accent-green-dim);
+}
+
+.btn-primary:hover {
+  background: var(--accent-green);
+  border-color: var(--accent-green);
+  color: #0d1117;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 20px rgba(126, 231, 135, 0.25);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border-color: var(--border-default);
+}
+
+.btn-secondary:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+/* --- Hero Code Block --- */
+.hero-code {
+  max-width: 580px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+/* ===========================
+   Code Window
+   =========================== */
+.code-window {
+  background: var(--bg-code);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.code-window-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.code-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.code-dot.red { background: #ff5f57; }
+.code-dot.yellow { background: #febc2e; }
+.code-dot.green { background: #28c840; }
+
+.code-window-title {
+  margin-left: 8px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+}
+
+.code-block {
+  padding: var(--space-lg);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.65;
+  color: var(--text-primary);
+  tab-size: 4;
+}
+
+.code-block code {
+  background: none;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Syntax highlighting classes */
+.c-keyword { color: var(--syn-keyword); }
+.c-string { color: var(--syn-string); }
+.c-func { color: var(--syn-func); }
+.c-number { color: var(--syn-number); }
+.c-comment { color: var(--syn-comment); }
+.c-var { color: var(--syn-var); }
+.c-module { color: var(--syn-module); }
+.c-op { color: var(--syn-op); }
+.c-directive { color: var(--syn-directive); font-weight: 600; }
+.c-lang { color: var(--syn-lang); font-weight: 600; }
+.c-math { color: var(--syn-math); }
+
+/* Inline code blocks (for troubleshooting) */
+.code-inline {
+  background: var(--bg-code);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  overflow-x: auto;
+  margin: var(--space-sm) 0;
+}
+
+/* ===========================
+   Sections
+   =========================== */
+.section {
+  padding: var(--space-4xl) 0;
+}
+
+.section-alt {
+  background: var(--bg-primary);
+}
+
+.section-title {
+  font-size: 2rem;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: var(--space-sm);
+  letter-spacing: -0.02em;
+}
+
+.section-subtitle {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  margin-bottom: var(--space-3xl);
+}
+
+/* ===========================
+   Features Grid
+   =========================== */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-lg);
+}
+
+.feature-card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl);
+  transition: border-color var(--transition), transform var(--transition);
+}
+
+.feature-card:hover {
+  border-color: var(--accent-green-dim);
+  transform: translateY(-2px);
+}
+
+.feature-icon {
+  font-size: 1.8rem;
+  margin-bottom: var(--space-md);
+}
+
+.feature-card h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: var(--space-sm);
+}
+
+.feature-card p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ===========================
+   Installation Tabs
+   =========================== */
+.install-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  padding: 3px;
+  max-width: 280px;
+  margin: 0 auto var(--space-xl);
+}
+
+.tab-btn {
+  flex: 1;
+  padding: 0.5em 1em;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.tab-btn.active {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.tab-btn:hover:not(.active) {
+  color: var(--text-primary);
+}
+
+.tab-content {
+  display: none;
+  max-width: 640px;
+  margin: 0 auto var(--space-2xl);
+}
+
+.tab-content.active {
+  display: block;
+}
+
+/* --- Requirements --- */
+.install-requirements {
+  max-width: 640px;
+  margin: 0 auto;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-xl);
+}
+
+.install-requirements h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: var(--space-md);
+}
+
+.install-requirements ul {
+  list-style: none;
+}
+
+.install-requirements li {
+  padding: 0.4em 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  position: relative;
+  padding-left: 1.2em;
+}
+
+.install-requirements li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: var(--accent-green-dim);
+}
+
+.install-requirements li a {
+  color: var(--text-link);
+}
+
+/* ===========================
+   Configuration
+   =========================== */
+.config-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-xl);
+  margin-bottom: var(--space-2xl);
+}
+
+.config-block h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: var(--space-md);
+  color: var(--text-secondary);
+}
+
+.config-table-wrap {
+  overflow-x: auto;
+}
+
+.config-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.config-table th {
+  text-align: left;
+  padding: 0.75em 1em;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.config-table td {
+  padding: 0.75em 1em;
+  border-bottom: 1px solid var(--border-muted);
+  color: var(--text-secondary);
+}
+
+.config-table td:first-child {
+  color: var(--accent-purple);
+}
+
+.config-table td code {
+  font-size: 0.85em;
+}
+
+/* ===========================
+   Supported Languages
+   =========================== */
+.lang-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+}
+
+.lang-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  transition: border-color var(--transition);
+}
+
+.lang-card:hover {
+  border-color: var(--accent-purple-dim);
+}
+
+.lang-card.lang-featured {
+  border-color: rgba(126, 231, 135, 0.3);
+  background: rgba(126, 231, 135, 0.03);
+}
+
+.lang-name {
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: var(--space-xs);
+}
+
+.lang-aliases {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.lang-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--accent-green);
+  background: rgba(126, 231, 135, 0.1);
+  padding: 0.2em 0.6em;
+  border-radius: 4px;
+  margin-top: var(--space-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.lang-install-hint {
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+/* ===========================
+   Commands
+   =========================== */
+.commands-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-lg);
+}
+
+.command-card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-xl);
+  transition: border-color var(--transition);
+}
+
+.command-card:hover {
+  border-color: var(--accent-purple-dim);
+}
+
+.command-name {
+  margin-bottom: var(--space-sm);
+}
+
+.command-name code {
+  font-size: 1rem;
+  background: rgba(188, 140, 255, 0.12);
+  color: var(--accent-purple);
+  padding: 0.25em 0.6em;
+}
+
+.command-card p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ===========================
+   Troubleshooting (FAQ)
+   =========================== */
+.faq-list {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.faq-item {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-md);
+  overflow: hidden;
+  transition: border-color var(--transition);
+}
+
+.faq-item:hover {
+  border-color: var(--text-muted);
+}
+
+.faq-item[open] {
+  border-color: var(--accent-green-dim);
+}
+
+.faq-item summary {
+  padding: var(--space-lg);
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  user-select: none;
+  transition: color var(--transition);
+}
+
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-item summary::after {
+  content: '+';
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  font-weight: 400;
+  transition: transform var(--transition);
+  flex-shrink: 0;
+  margin-left: var(--space-md);
+}
+
+.faq-item[open] summary::after {
+  content: '−';
+  color: var(--accent-green);
+}
+
+.faq-item[open] summary {
+  color: var(--accent-green);
+}
+
+.faq-answer {
+  padding: 0 var(--space-lg) var(--space-lg);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.7;
+}
+
+.faq-answer ol {
+  padding-left: 1.4em;
+  list-style: decimal;
+}
+
+.faq-answer ol li {
+  margin-bottom: 0.4em;
+}
+
+.faq-answer p {
+  margin-bottom: 0.6em;
+}
+
+/* ===========================
+   Footer
+   =========================== */
+.footer {
+  border-top: 1px solid var(--border-default);
+  padding: var(--space-3xl) 0 var(--space-xl);
+  background: var(--bg-primary);
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: var(--space-2xl);
+  margin-bottom: var(--space-2xl);
+}
+
+.footer-logo {
+  font-weight: 600;
+  font-size: 1.05rem;
+  margin-bottom: var(--space-md);
+  color: var(--text-primary);
+}
+
+.footer-about p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-bottom: var(--space-sm);
+}
+
+.footer-org a {
+  color: var(--accent-green-dim);
+}
+
+.footer-links-section h4 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: var(--space-md);
+}
+
+.footer-links-section li {
+  margin-bottom: var(--space-sm);
+}
+
+.footer-links-section a {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.footer-links-section a:hover {
+  color: var(--text-primary);
+}
+
+.footer-bottom {
+  border-top: 1px solid var(--border-muted);
+  padding-top: var(--space-xl);
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* ===========================
+   Responsive
+   =========================== */
+@media (max-width: 900px) {
+  .features-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .commands-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .config-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-links {
+    display: none;
+    position: absolute;
+    top: 64px;
+    left: 0;
+    right: 0;
+    background: var(--bg-primary);
+    border-bottom: 1px solid var(--border-default);
+    flex-direction: column;
+    padding: var(--space-md) var(--space-lg);
+    gap: var(--space-sm);
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: flex;
+  }
+
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-title {
+    font-size: 2rem;
+  }
+
+  .hero-subtitle {
+    font-size: 1rem;
+  }
+
+  .section-title {
+    font-size: 1.6rem;
+  }
+
+  .hero {
+    padding-top: calc(64px + var(--space-2xl));
+    padding-bottom: var(--space-2xl);
+  }
+
+  .section {
+    padding: var(--space-2xl) 0;
+  }
+
+  .hero-code {
+    margin: 0 calc(-1 * var(--space-md));
+  }
+
+  .lang-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* ===========================
+   Animations
+   =========================== */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero-badge,
+.hero-title,
+.hero-subtitle,
+.hero-actions,
+.hero-code {
+  animation: fadeInUp 0.6s ease forwards;
+}
+
+.hero-title { animation-delay: 0.1s; }
+.hero-subtitle { animation-delay: 0.2s; }
+.hero-actions { animation-delay: 0.3s; }
+.hero-code { animation-delay: 0.4s; }
+
+/* Scroll reveal (applied via JS) */
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/website/style.css
+++ b/website/style.css
@@ -53,8 +53,8 @@
   --space-4xl: 6rem;
 
   /* Typography */
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', Menlo, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'Fira Code', 'Cascadia Code', 'SF Mono', Menlo, monospace;
 
   /* Misc */
   --radius-sm: 6px;
@@ -76,6 +76,12 @@
 html {
   scroll-behavior: smooth;
   scroll-padding-top: 80px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
 }
 
 body {
@@ -1117,4 +1123,20 @@ ul {
 .reveal.visible {
   opacity: 1;
   transform: translateY(0);
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .reveal {
+    opacity: 1;
+    transform: none;
+  }
 }

--- a/website/style.css
+++ b/website/style.css
@@ -410,6 +410,14 @@ ul {
 .c-lang { color: var(--syn-lang); font-weight: 600; }
 .c-math { color: var(--syn-math); }
 
+/* LaTeX syntax */
+.c-tex-cmd { color: #d2a8ff; }        /* \begin, \end — purple, like functions */
+.c-tex-brace { color: #8b949e; }      /* { } — muted gray */
+.c-tex-env { color: #7ee787; }        /* aligned — green, like identifiers */
+.c-tex-var { color: #e6edf3; }        /* E, F, mc, ma — primary text */
+.c-tex-op { color: #ff7b72; }         /* &=, \\, ^  — red, like operators */
+.c-tex-sup { color: #79c0ff; }        /* ^2 — blue, like numbers */
+
 /* Inline code blocks (for troubleshooting) */
 .code-inline {
   background: var(--bg-code);


### PR DESCRIPTION
## Summary

Add a single-page dark-themed website for the plugin, deployable via GitHub Pages.

## What's Included

### Website (`website/` directory)
- **Single-page site** with smooth anchor navigation
- **Dark theme** with Neovim green + MyST purple accent colors
- **Hero section** with syntax-highlighted MyST code example
- **Theme switcher** — shows code in 4 popular Neovim colorschemes (GitHub Dark, Catppuccin Mocha, Tokyo Night, One Dark)
- **Sections:** Features, Installation (tabbed for lazy.nvim/packer), Configuration, Supported Languages, Commands, Troubleshooting (accordion FAQ)
- **Responsive** — mobile hamburger nav, reflowing grids
- **Zero dependencies** — plain HTML/CSS/JS
- **`</>` code brackets icon** for nav logo, footer, and favicon

### Deployment
- **GitHub Actions workflow** (`.github/workflows/deploy-website.yml`) — auto-deploys on push to `main` when `website/` changes
- Uses `actions/deploy-pages@v4` (modern approach, no separate gh-pages branch)
- `.nojekyll` file included

### Other
- Updated copilot instructions for `gh` CLI usage (use `create_file` + `--body-file` instead of heredocs)

### Setup Required
After merging, enable GitHub Pages in repo settings:
1. Go to **Settings > Pages**
2. Set Source to **GitHub Actions**

The workflow will handle the rest automatically on future pushes.
