### PR TITLE
feat(website): improve browser tab with polished favicon and meta tags

### DIFF
--- a/website/favicon.svg
+++ b/website/favicon.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#161b22"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7ee787"/>
+      <stop offset="100%" stop-color="#56d364"/>
+    </linearGradient>
+    <linearGradient id="purple" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#d2a8ff"/>
+      <stop offset="100%" stop-color="#bc8cff"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="128" height="128" rx="22" fill="url(#bg)"/>
+  <!-- Subtle border -->
+  <rect width="126" height="126" x="1" y="1" rx="21" fill="none" stroke="#30363d" stroke-width="1.5"/>
+  <!-- Left bracket < -->
+  <path d="M48 40L24 64L48 88" stroke="url(#accent)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <!-- Right bracket > -->
+  <path d="M80 40L104 64L80 88" stroke="url(#accent)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <!-- Slash / -->
+  <path d="M72 32L56 96" stroke="url(#purple)" stroke-width="7" stroke-linecap="round" fill="none"/>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -3,10 +3,23 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>myst-markdown-tree-sitter.nvim — MyST Syntax Highlighting for Neovim</title>
+  <title>MyST for Neovim — Tree-sitter Syntax Highlighting</title>
   <meta name="description" content="Tree-sitter powered syntax highlighting for MyST Markdown in Neovim. Code-cell directives, math blocks, and 10+ languages.">
+  <meta name="theme-color" content="#0d1117">
+  <meta name="color-scheme" content="dark">
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="MyST for Neovim">
+  <meta property="og:description" content="Tree-sitter powered syntax highlighting for MyST Markdown in Neovim. Code-cell directives, math blocks, and 10+ languages.">
+  <meta property="og:url" content="https://quantecon.github.io/myst-markdown-tree-sitter.nvim/">
+  <meta property="og:image" content="https://quantecon.github.io/myst-markdown-tree-sitter.nvim/og-image.png">
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="MyST for Neovim">
+  <meta name="twitter:description" content="Tree-sitter syntax highlighting for MyST Markdown in Neovim.">
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="style.css">
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect rx='16' width='100' height='100' fill='%230d1117'/><text x='50' y='58' font-family='monospace' font-size='52' font-weight='bold' fill='%237ee787' text-anchor='middle' dominant-baseline='middle'>&lt;/&gt;</text></svg>">
 </head>
 <body>
   <!-- Navigation -->


### PR DESCRIPTION
## Summary

Improve the browser tab appearance for the plugin website.

## Changes

- **Favicon**: New standalone SVG file with gradient `</>` brackets (green) and slash (purple) on a dark rounded-rect background — much crisper at small sizes than the previous inline data URI
- **Tab title**: Shortened to "MyST for Neovim — Tree-sitter Syntax Highlighting" (front-loads the brand name)
- **Theme color**: `meta theme-color` set to `#0d1117` so mobile browsers tint their chrome to match
- **Open Graph / Twitter Card**: Social sharing previews now show proper title, description, and URL
- **Color scheme**: `meta color-scheme` set to `dark`

## Notes

- The `og:image` tag references an `og-image.png` that can be added later (a screenshot of the site)
