### PR TITLE
fix(website): use absolute paths for favicons to fix Safari

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -17,10 +17,11 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="MyST for Neovim">
   <meta name="twitter:description" content="Tree-sitter syntax highlighting for MyST Markdown in Neovim.">
-  <!-- Favicon: ico for Safari, SVG for modern browsers, apple-touch-icon for iOS -->
-  <link rel="icon" href="favicon.ico" sizes="48x48">
-  <link rel="icon" type="image/svg+xml" sizes="any" href="favicon.svg">
-  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <!-- Favicon: absolute URLs to prevent Safari resolving from domain root -->
+  <link rel="icon" href="/myst-markdown-tree-sitter.nvim/favicon.ico" sizes="48x48">
+  <link rel="icon" type="image/svg+xml" sizes="any" href="/myst-markdown-tree-sitter.nvim/favicon.svg">
+  <link rel="apple-touch-icon" sizes="180x180" href="/myst-markdown-tree-sitter.nvim/apple-touch-icon.png">
+  <link rel="mask-icon" href="/myst-markdown-tree-sitter.nvim/favicon.svg" color="#7ee787">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary

Safari on GitHub Pages subpath sites (e.g. `quantecon.github.io/myst-markdown-tree-sitter.nvim/`) resolves favicon URLs from the domain root instead of the page's directory. This causes it to pick up GitHub's default "G" favicon.

## Changes

- Changed all favicon `href` values from relative (`favicon.ico`) to absolute (`/myst-markdown-tree-sitter.nvim/favicon.ico`)
- Added `rel="mask-icon"` for Safari pinned tabs

## Favicon link order

1. `.ico` (48x48) — Safari and legacy browsers
2. `.svg` (any size) — Chrome, Firefox, Edge
3. `apple-touch-icon` (180x180) — iOS home screen
4. `mask-icon` — Safari pinned tabs
