### PR TITLE
fix(website): add cache buster to favicon URLs for Safari

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -17,9 +17,9 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="MyST for Neovim">
   <meta name="twitter:description" content="Tree-sitter syntax highlighting for MyST Markdown in Neovim.">
-  <!-- Favicon: absolute URLs to prevent Safari resolving from domain root -->
-  <link rel="icon" href="/myst-markdown-tree-sitter.nvim/favicon.ico" sizes="48x48">
-  <link rel="icon" type="image/svg+xml" sizes="any" href="/myst-markdown-tree-sitter.nvim/favicon.svg">
+  <!-- Favicon: root-relative paths with cache buster for Safari -->
+  <link rel="icon" href="/myst-markdown-tree-sitter.nvim/favicon.ico?v=2" sizes="48x48">
+  <link rel="icon" type="image/svg+xml" sizes="any" href="/myst-markdown-tree-sitter.nvim/favicon.svg?v=2">
   <link rel="apple-touch-icon" sizes="180x180" href="/myst-markdown-tree-sitter.nvim/apple-touch-icon.png">
   <link rel="mask-icon" href="/myst-markdown-tree-sitter.nvim/favicon.svg" color="#7ee787">
   <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
## Summary

Add `?v=2` cache buster to favicon URLs as a last-ditch attempt to fix Safari's favicon on GitHub Pages subpath sites. This is a known Safari/WebKit bug — Safari caches favicons per domain rather than per path.

## Changes

- Added `?v=2` query string to `.ico` and `.svg` favicon `href` values
