### PR TITLE
fix: add ';; extends' modeline to injections.scm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   override-by-priority. Without it, a higher-priority injections query — notably nvim-treesitter's
   `main` branch, which installs queries into `stdpath('data')/site` — fully replaced this file,
   silently dropping the `{code-cell}` and `{math}` injection rules so Python (and other languages)
-  stopped highlighting inside code-cell blocks. (`highlights.scm` already had this modeline.)
+  stopped highlighting inside code-cell blocks. (`highlights.scm` already carried this modeline;
+  both query files now use the same `;; extends` form for consistency.)
 
 ## [0.5.1] - 2026-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Improved troubleshooting docs** — added guidance for conflicts with standalone `myst-markdown`
   plugins and lazy loading issues.
 
+### Fixed
+- **Code-cell language injection no longer lost when nvim-treesitter `main` is installed** —
+  `queries/markdown/injections.scm` now starts with a `;; extends` modeline so its rules merge
+  with other `markdown/injections.scm` files on the runtimepath instead of participating in
+  override-by-priority. Without it, a higher-priority injections query — notably nvim-treesitter's
+  `main` branch, which installs queries into `stdpath('data')/site` — fully replaced this file,
+  silently dropping the `{code-cell}` and `{math}` injection rules so Python (and other languages)
+  stopped highlighting inside code-cell blocks. (`highlights.scm` already had this modeline.)
+
 ## [0.5.1] - 2026-02-17
 
 ### Fixed

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -1,4 +1,4 @@
-; extends
+;; extends
 
 ;; MyST {math} directive: apply math styling to content
 ;; This gives {math} blocks the same base @markup.math highlight that

--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -1,6 +1,16 @@
+;; extends
+;;
 ;; MyST Markdown Language Injection Queries (Enhanced)
 ;; These queries extend standard markdown with MyST code-cell support
 ;; Support code-cells with optional YAML configuration blocks
+;;
+;; The `;; extends` modeline above is required: it tells Neovim to MERGE these
+;; rules with other markdown/injections.scm files on the runtimepath instead of
+;; participating in override-by-priority. Without it, any higher-priority
+;; markdown injections query -- notably nvim-treesitter's `main` branch, which
+;; installs queries into stdpath('data')/site -- fully replaces this file, and
+;; code-cell language injection is silently lost. (highlights.scm already has
+;; this modeline.)
 
 ;; MyST code-cell injection patterns (processed first)
 ;; Inject Python parser into code-cell python blocks


### PR DESCRIPTION
## Problem

`queries/markdown/highlights.scm` starts with a `;; extends` modeline, but `queries/markdown/injections.scm` does not. Without it, the injections query participates in Neovim's runtimepath *override-by-priority* rather than merging.

When a higher-priority `markdown/injections.scm` exists on the runtimepath — most importantly **nvim-treesitter's `main` branch**, which installs its query distribution into `stdpath('data')/site` — Neovim treats that file as a full replacement and silently discards this plugin's `{code-cell}` and `{math}` injection rules. The visible symptom: Python (and every other language) stops being highlighted inside `{code-cell}` blocks, with no error message.

The runtime file ordering looks like this (highest priority first):

```
.../site/queries/markdown/injections.scm        <- nvim-treesitter main, wins, no code-cell rules
.../myst-markdown-tree-sitter.nvim/queries/...   <- this plugin, ignored (no ;; extends)
.../nvim/runtime/queries/markdown/injections.scm <- builtin
```

The winning file's only rule reads the info-string's first token as the language, so `{code-cell} ipython3` resolves to a parser named `{code-cell}` (nonexistent) and nothing is injected.

## Fix

Add `;; extends` as the first line of `queries/markdown/injections.scm`, matching what `highlights.scm` already does. This makes the rules *merge* with other markdown injection queries on the runtimepath instead of being overridden by them.

## Verification

With nvim-treesitter `main` installed, before the fix the active parse trees for a MyST `.md` buffer are `{markdown, markdown_inline, latex}` — no `python`. After adding the modeline (verified via an `after/queries/` shim with the same content), the trees become `{markdown, markdown_inline, latex, python}` and code-cell blocks highlight correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)